### PR TITLE
Lobby player issues found.

### DIFF
--- a/pkg/db/lobbyplayer.go
+++ b/pkg/db/lobbyplayer.go
@@ -42,7 +42,7 @@ func (l *lobbyplayer) Add(lobbyId *string, sessionId *string, connectionId *stri
 			"#Points":       "Points",
 		},
 		UpdateExpression: aws.String("set #ConnectionId=:ConnectionId, #IsAdmin=:IsAdmin, #Id=if_not_exists(#Id, :Id), #Name=if_not_exists(#Name, :Name), #Points=if_not_exists(#Points, :Points)"),
-		ReturnValues:     types.ReturnValueAllOld,
+		ReturnValues:     types.ReturnValueAllNew,
 	})
 
 	if err != nil {

--- a/pkg/services/lobby.go
+++ b/pkg/services/lobby.go
@@ -65,9 +65,5 @@ func join(context *models.Context, isAdmin bool) error {
 	}
 
 	route = models.NewRoute(&models.Service.Lobby, &lobby.Action.Server.PlayerJoined)
-	err = ws.SendToLobby(context, route, lobby.PlayerJoinResponse{Player: player})
-
-	if err != nil {
-		return err
-	}
+	return ws.SendToLobby(context, route, lobby.PlayerJoinResponse{Player: player})
 }

--- a/pkg/services/lobby.go
+++ b/pkg/services/lobby.go
@@ -51,19 +51,23 @@ func join(context *models.Context, isAdmin bool) error {
 		return err
 	}
 
-	route := models.NewRoute(&models.Service.Lobby, &lobby.Action.Server.PlayerJoined)
-	err = ws.SendToLobby(context, route, lobby.PlayerJoinResponse{Player: player})
-
-	if err != nil {
-		return err
-	}
-
 	players, err := db.LobbyPlayer.GetPlayers(context.LobbyId())
 
 	if err != nil {
 		return err
 	}
 
-	route = models.NewRoute(&models.Service.Lobby, &lobby.Action.Server.Joined)
-	return ws.Send(context, route, lobby.GetResponse{Player: player, Lobby: lobby.Details{Players: players, LobbyId: *context.LobbyId()}})
+	route := models.NewRoute(&models.Service.Lobby, &lobby.Action.Server.Joined)
+	err = ws.Send(context, route, lobby.GetResponse{Player: player, Lobby: lobby.Details{Players: players, LobbyId: *context.LobbyId()}})
+
+	if err != nil {
+		return err
+	}
+
+	route = models.NewRoute(&models.Service.Lobby, &lobby.Action.Server.PlayerJoined)
+	err = ws.SendToLobby(context, route, lobby.PlayerJoinResponse{Player: player})
+
+	if err != nil {
+		return err
+	}
 }


### PR DESCRIPTION
- Ensure that all the data get returned form t he Add method not just the old stuff. Fixes issues where new players wouldn't be returned an id.

- flip to telling the new player about the lobby and then telling the lobby about the new player. If issues occur before the new player knows about the lobby then the lobby shouldn't be told about them.