### PR TITLE
Allow name to be passed in when creating / joining a lobby.

### DIFF
--- a/pkg/db/lobbyplayer.go
+++ b/pkg/db/lobbyplayer.go
@@ -18,7 +18,7 @@ type lobbyplayer struct {
 
 var LobbyPlayer = lobbyplayer{table: "LobbyPlayer"}
 
-func (l *lobbyplayer) Add(lobbyId *string, sessionId *string, connectionId *string, isAdmin bool) (lobby.Player, error) {
+func (l *lobbyplayer) Add(lobbyId *string, sessionId *string, connectionId *string, name string, isAdmin bool) (lobby.Player, error) {
 	var player lobby.Player
 
 	item, err := DynamoDb.UpdateItem(context.TODO(), &dynamodb.UpdateItemInput{
@@ -30,7 +30,7 @@ func (l *lobbyplayer) Add(lobbyId *string, sessionId *string, connectionId *stri
 		ExpressionAttributeValues: map[string]types.AttributeValue{
 			":ConnectionId": &types.AttributeValueMemberS{Value: *connectionId},
 			":Id":           &types.AttributeValueMemberS{Value: uuid.New().String()},
-			":Name":         &types.AttributeValueMemberS{Value: ""},
+			":Name":         &types.AttributeValueMemberS{Value: name},
 			":Points":       &types.AttributeValueMemberN{Value: "0"},
 			":IsAdmin":      &types.AttributeValueMemberBOOL{Value: isAdmin},
 		},

--- a/pkg/models/lobby/request.go
+++ b/pkg/models/lobby/request.go
@@ -1,5 +1,9 @@
 package lobby
 
+type CreateAndJoinRequest struct {
+	Name string `json:"name"`
+}
+
 type SetNameRequest struct {
 	Text string `json:"text"`
 }

--- a/pkg/services/lobby.go
+++ b/pkg/services/lobby.go
@@ -9,21 +9,35 @@ import (
 )
 
 func CreateLobby(context *models.Context, data *models.Data) error {
-	id := uuid.New().String()
-
-	context = context.ForLobby(&id)
-
-	err := db.Lobby.Add(context.LobbyId())
+	req := lobby.CreateAndJoinRequest{}
+	err := data.DecodeTo(&req)
 
 	if err != nil {
 		return err
 	}
 
-	return join(context, true)
+	id := uuid.New().String()
+
+	context = context.ForLobby(&id)
+
+	err = db.Lobby.Add(context.LobbyId())
+
+	if err != nil {
+		return err
+	}
+
+	return join(context, req.Name, true)
 }
 
 func JoinLobby(context *models.Context, data *models.Data) error {
-	return join(context, false)
+	req := lobby.CreateAndJoinRequest{}
+	err := data.DecodeTo(&req)
+
+	if err != nil {
+		return err
+	}
+
+	return join(context, req.Name, false)
 }
 
 func SetLobbyName(context *models.Context, data *models.Data) error {
@@ -44,8 +58,8 @@ func SetLobbyName(context *models.Context, data *models.Data) error {
 	return ws.SendToLobby(context, route, lobby.NameChangeResponse{Player: player})
 }
 
-func join(context *models.Context, isAdmin bool) error {
-	player, err := db.LobbyPlayer.Add(context.LobbyId(), context.SessionId(), context.ConnectionId(), isAdmin)
+func join(context *models.Context, name string, isAdmin bool) error {
+	player, err := db.LobbyPlayer.Add(context.LobbyId(), context.SessionId(), context.ConnectionId(), name, isAdmin)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
This will allow us to remove the name change step and merge it into the join/create step reducing messages and steps in the process.